### PR TITLE
feat: change autopy trigger rule to also fire in new windows/panes

### DIFF
--- a/conf.d/autopy.fish
+++ b/conf.d/autopy.fish
@@ -1,5 +1,5 @@
 
-function autopy --on-variable PWD
+function autopy --on-event fish_prompt
   if is_venv_active && is_child_dir
     return
   end


### PR DESCRIPTION
Hi @SpaceShaman, thanks for the plugin.

This PR proposes a change that would also trigger autopy in cases when a new window/terminal pane is created (e.g. in tmux or a multiplexing terminal like wezterm). If I'm in a project folder and create a new horizontal/vertical pane that would be in the same folder, autopy will not trigger in this case.