### PR TITLE
Fix error spam when which or python are not installed.

### DIFF
--- a/conf.d/autopy.fish
+++ b/conf.d/autopy.fish
@@ -29,7 +29,9 @@ function autopy --on-event fish_prompt
 end
 
 function is_venv_active
-  test (command which python) = "$VIRTUAL_ENV/bin/python"
+  set -l python_path (type --path python)
+  set -q $python_path
+  and test $python_path = "$VIRTUAL_ENV/bin/python"
 end
 
 function is_child_dir
@@ -76,7 +78,6 @@ function is_poetry_project -a dir
   command -q poetry && test -e "$dir/pyproject.toml"
 end
 
-
 function is_outside_venv -a dir
   test "$VIRTUAL_ENV" != "$dir"
 end
@@ -94,4 +95,3 @@ function deactivate_venv
   deactivate
   set -gx OLD_PROJECT_DIR ""
 end
-


### PR DESCRIPTION
I tried my dotfiles in a bare-bones Archlinux container, where  neither `which` nor `python` is installed and `autopy` breaks:
```fish
fish: Unknown command: which
~/.config/fish/conf.d/autopy.fish (line 1): 
command which python
        ^~~~^
in command substitution
	called on line 32 of file ~/.config/fish/conf.d/autopy.fish
in function 'is_venv_active'
	called on line 3 of file ~/.config/fish/conf.d/autopy.fish
in function 'autopy'
~/.config/fish/conf.d/autopy.fish (line 32): Unknown command
  test (command which python) = "$VIRTUAL_ENV/bin/python"
       ^~~~~~~~~~~~~~~~~~~~~^
in function 'is_venv_active'
	called on line 3 of file ~/.config/fish/conf.d/autopy.fish
in function 'autopy'
fish: Unknown command: which
~/.config/fish/conf.d/autopy.fish (line 1): 
command which python
        ^~~~^
in command substitution
	called on line 32 of file ~/.config/fish/conf.d/autopy.fish
in function 'is_venv_active'
	called on line 9 of file ~/.config/fish/conf.d/autopy.fish
in function 'autopy'
~/.config/fish/conf.d/autopy.fish (line 32): Unknown command
  test (command which python) = "$VIRTUAL_ENV/bin/python"
       ^~~~~~~~~~~~~~~~~~~~~^
in function 'is_venv_active'
	called on line 9 of file ~/.config/fish/conf.d/autopy.fish
in function 'autopy'
```
If you install `which` but still leave `python` missing it still breaks:
```fish
which: no python in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin)
test: Missing argument at index 3
= /bin/python
              ^
~/.config/fish/conf.d/autopy.fish (line 32): 
  test (command which python) = "$VIRTUAL_ENV/bin/python"
  ^
in function 'is_venv_active'
	called on line 3 of file ~/.config/fish/conf.d/autopy.fish
in function 'autopy'
which: no python in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin)
test: Missing argument at index 3
= /bin/python
              ^
~/.config/fish/conf.d/autopy.fish (line 32): 
  test (command which python) = "$VIRTUAL_ENV/bin/python"
  ^
in function 'is_venv_active'
	called on line 9 of file ~/.config/fish/conf.d/autopy.fish
in function 'autopy'
```
This simple change fixes both of those errors and should even be a bit faster because `which` is a bit slow IIRC.
Thank you for this great fish plugin!